### PR TITLE
/dev/shm lockdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,12 +540,18 @@ And set `nodev`, `nosuid` and `noexec` mount options in `/etc/fstab`.
 
 #### :eight_pointed_black_star: Secure /dev/shm
 
-`/dev/shm` is a temporary file storage filesystem, i.e. **tmpfs**, that uses RAM for the backing store. One of the major security issue with the `/dev/shm` is anyone can upload and execute files inside the `/dev/shm` similar to the `/tmp` partition.
+`/dev/shm` is a temporary file storage filesystem, i.e. **tmpfs**, that uses RAM for the backing store. One of the major security issue with the `/dev/shm` is anyone can upload and execute files inside the `/dev/shm` similar to the `/tmp` partition. Further the size should be limited to avoid an attacker filling up this mountpoint to the point where applications could be affected. (normally it allows 20% or more of RAM to be used). The sticky bit should be set like for any world writeable directory.
 
 For applies to shared memory `/dev/shm` mount params:
 
 ```bash
-tmpfs  /dev/shm  tmpfs  rw,nodev,nosuid,noexec 0 0
+tmpfs  /dev/shm  tmpfs  rw,nodev,nosuid,noexec,size=1024M,mode=1777 0 0
+```
+
+  > You can also create a group named 'shm' and put application users for SHM-using applications in there. Then the access can be completely be restricted as such:
+  
+```bash
+tmpfs  /dev/shm  tmpfs  rw,nodev,nosuid,noexec,mode=1770,size=1024M 0 0
 ```
 
 #### :eight_pointed_black_star: Secure /proc filesystem

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ tmpfs  /dev/shm  tmpfs  rw,nodev,nosuid,noexec,size=1024M,mode=1777 0 0
   > You can also create a group named 'shm' and put application users for SHM-using applications in there. Then the access can be completely be restricted as such:
   
 ```bash
-tmpfs  /dev/shm  tmpfs  rw,nodev,nosuid,noexec,mode=1770,size=1024M 0 0
+tmpfs  /dev/shm  tmpfs  rw,nodev,nosuid,noexec,size=1024M,mode=1770,uid=root,gid=shm 0 0
 ```
 
 #### :eight_pointed_black_star: Secure /proc filesystem


### PR DESCRIPTION
- add sticky bit
- limit size
- note you can have a group for any legit user and remove "world" access
(/dev/shm is an idiocy anyway, by applying some permissions it gets at least 'closer' to normal SHM security model)